### PR TITLE
perf: faster build times

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 # Install Go
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && \
     apt-get install software-properties-common -y
 
 RUN add-apt-repository ppa:longsleep/golang-backports && \

--- a/docker/integration-tests/Dockerfile
+++ b/docker/integration-tests/Dockerfile
@@ -1,12 +1,4 @@
-FROM debian:buster-slim
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y nodejs unzip npm curl \
-    && curl -fsSL https://bun.sh/install | bash \
-    && echo 'export PATH="$HOME/.bun/bin:$PATH"' >> $HOME/.bashrc
-
-ENV PATH="/root/.bun/bin:${PATH}"
+FROM oven/bun:latest
 
 WORKDIR /root/app
 


### PR DESCRIPTION
Just making the build times of the tests faster. Integration tests do a whole lot of upgrades before we even do anything.