### PR TITLE
ci: docker cloud file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .DS_Store
 tmp/
+bin/
 
 .env.*
 !.env.example

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -2,25 +2,22 @@
 
 # The command to run when everything is ready
 [build]
-  cmd = "go build -o ./tmp/main ./cmd/main.go"
-  bin = "tmp/main"
-  log = "tmp/build-errors.log"
+cmd = "go build -o ./bin/main ./cmd/main.go"
+bin = "bin/main"
+log = "bin/build-errors.log"
 
 # Watch these directories for changes
 [watch]
-  # List of search paths
-  includes = [
-    "cmd/**/*",
-    "internal/**/*"
-  ]
-  # Exclude the tmp directory from being watched
-  excludes = ["tmp"]
-  delay = 1000 # in milliseconds
+# List of search paths
+includes = ["cmd/**/*", "internal/**/*"]
+# Exclude the tmp directory from being watched
+excludes = ["bin"]
+delay = 1000       # in milliseconds
 
 # Configurations for log output
 [log]
-  level = "info"
-  color = true
+level = "info"
+color = true
 
 
 # Send interrupt signal before killing process

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+# Install necessary packages and add Go repository
+RUN apt-get update && \
+    apt-get install -y software-properties-common ca-certificates curl && \
+    add-apt-repository ppa:longsleep/golang-backports
+
+# Install Go
+RUN apt-get update && \
+    apt-get install -y golang-go
+
+ENV GO111MODULE=on
+
+# show Go version
+ENV PATH=$PATH:/root/go/bin
+RUN go version
+
+# Set the current working directory
+WORKDIR /root/app
+
+# Copy go mod and sum files to the workspace
+COPY backend/go.mod backend/go.sum ./
+
+# Download all dependencies
+RUN go mod download
+
+# Copy the source code into the container
+COPY backend/ .
+
+# Expose port 8080 for the application
+EXPOSE 8080
+
+# Command to run the application with realize for hot reloading
+CMD ["go", "run", "cmd/main.go"]


### PR DESCRIPTION
Started a DEV deploy on render. Once this is merged then I can reroute the dockerfile expected path.

This is just minimalist, removing the need for `air` as we are not hot-reloading.