### PR TITLE
refactor: dto level validation

### DIFF
--- a/backend/core/api/congregation/dtos.go
+++ b/backend/core/api/congregation/dtos.go
@@ -3,15 +3,15 @@ package congregation
 import "backend/core/db/models"
 
 type VerifyCongregationPhoneDTO struct {
-	UserCode     string              `json:"userCode"`
-	Congregation models.Congregation `json:"congregation"`
+	UserCode     string              `json:"userCode" validate:"required"`
+	Congregation models.Congregation `json:"congregation" validate:"required"`
 }
 
 type SendCongregationVerificationCodeDTO struct {
-	PhoneNumber  string              `json:"phoneNumber"`
-	Congregation models.Congregation `json:"congregation"`
+	PhoneNumber  string              `json:"phoneNumber" validate:"required"`
+	Congregation models.Congregation `json:"congregation" validate:"required"`
 }
 
 type DeleteCongregationDTO struct {
-	CongregationId uint `json:"congregationId"`
+	CongregationId uint `json:"congregationId" validate:"required"`
 }

--- a/backend/core/api/congregation/views.go
+++ b/backend/core/api/congregation/views.go
@@ -17,7 +17,7 @@ func CreateCongregation(ctx *gin.Context) {
 	 */
 
 	var dto models.Congregation
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println("[CreateCongregation] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -62,7 +62,7 @@ func CreateCongregation(ctx *gin.Context) {
 
 func DeleteCongregation(ctx *gin.Context) {
 	var dto DeleteCongregationDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println("[DeleteCongregation] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -86,7 +86,7 @@ func DeleteCongregation(ctx *gin.Context) {
 
 func SendCongregationVerificationCode(ctx *gin.Context) {
 	var dto SendCongregationVerificationCodeDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println("[SendCongregationVerificationCode] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -125,7 +125,7 @@ func SendCongregationVerificationCode(ctx *gin.Context) {
 
 func VerifyCongregationPhone(ctx *gin.Context) {
 	var dto VerifyCongregationPhoneDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println("[VerifyCongregationPhone] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{

--- a/backend/core/api/congregation/views.go
+++ b/backend/core/api/congregation/views.go
@@ -17,7 +17,7 @@ func CreateCongregation(ctx *gin.Context) {
 	 */
 
 	var dto models.Congregation
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println("[CreateCongregation] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -62,7 +62,7 @@ func CreateCongregation(ctx *gin.Context) {
 
 func DeleteCongregation(ctx *gin.Context) {
 	var dto DeleteCongregationDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println("[DeleteCongregation] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -86,7 +86,7 @@ func DeleteCongregation(ctx *gin.Context) {
 
 func SendCongregationVerificationCode(ctx *gin.Context) {
 	var dto SendCongregationVerificationCodeDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println("[SendCongregationVerificationCode] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{
@@ -125,7 +125,7 @@ func SendCongregationVerificationCode(ctx *gin.Context) {
 
 func VerifyCongregationPhone(ctx *gin.Context) {
 	var dto VerifyCongregationPhoneDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println("[VerifyCongregationPhone] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{

--- a/backend/core/api/find-meetings/dtos.go
+++ b/backend/core/api/find-meetings/dtos.go
@@ -1,6 +1,6 @@
 package findmeetings
 
 type FindLocalMeetingsRequestDTO struct {
-	Latitude  string `json:"latitude"`
-	Longitude string `json:"longitude"`
+	Latitude  string `json:"latitude" validate:"required"`
+	Longitude string `json:"longitude" validate:"required"`
 }

--- a/backend/core/api/find-meetings/views.go
+++ b/backend/core/api/find-meetings/views.go
@@ -12,7 +12,7 @@ import (
 func FindLocalMeetings(ctx *gin.Context) {
 	var dto FindLocalMeetingsRequestDTO
 
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println(err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/core/api/find-meetings/views.go
+++ b/backend/core/api/find-meetings/views.go
@@ -1,6 +1,7 @@
 package findmeetings
 
 import (
+	"backend/core/common"
 	meetingfinder "backend/core/integrations/meeting-finder"
 	"fmt"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 func FindLocalMeetings(ctx *gin.Context) {
 	var dto FindLocalMeetingsRequestDTO
 
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println(err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/core/api/token/dtos.go
+++ b/backend/core/api/token/dtos.go
@@ -1,6 +1,6 @@
 package token
 
 type CreateTokenDTO struct {
-	UserEmail       string `json:"userEmail"`
-	CreatedByUserId uint   `json:"createdByUserId"`
+	UserEmail       string `json:"userEmail" validate:"required"`
+	CreatedByUserId uint   `json:"createdByUserId" validate:"required"`
 }

--- a/backend/core/api/token/views.go
+++ b/backend/core/api/token/views.go
@@ -22,7 +22,7 @@ func CreateToken(ctx *gin.Context) {
 
 	var dto CreateTokenDTO
 
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		fmt.Println("[CreateToken] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{

--- a/backend/core/api/token/views.go
+++ b/backend/core/api/token/views.go
@@ -22,7 +22,7 @@ func CreateToken(ctx *gin.Context) {
 
 	var dto CreateTokenDTO
 
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		fmt.Println("[CreateToken] incorrect payload.")
 		ctx.JSON(http.StatusBadRequest, gin.H{

--- a/backend/core/api/user/dtos.go
+++ b/backend/core/api/user/dtos.go
@@ -3,24 +3,24 @@ package user
 import "backend/core/db/models"
 
 type CreateUserDTO struct {
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	Email     string `json:"email"`
-	Password  string `json:"password"`
+	FirstName string `json:"firstName" validate:"required"`
+	LastName  string `json:"lastName" validate:"required"`
+	Email     string `json:"email" validate:"required"`
+	Password  string `json:"password" validate:"required"`
 
-	Type models.UserType `json:"type"`
+	Type models.UserType `json:"type" validate:"required"`
 }
 
 type LoginUserDTO struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	Email    string `json:"email" validate:"required"`
+	Password string `json:"password" validate:"required"`
 }
 
 type BindAdminToCongregationDTO struct {
-	CongregationID uint `json:"congregationId"`
+	CongregationID uint `json:"congregationId" validate:"required"`
 }
 
 type JoinTokenMatchDTO struct {
-	Email          string `json:"email"`
-	JoinTokenValue string `json:"tokenValue"`
+	Email          string `json:"email" validate:"required"`
+	JoinTokenValue string `json:"tokenValue" validate:"required"`
 }

--- a/backend/core/api/user/views.go
+++ b/backend/core/api/user/views.go
@@ -21,7 +21,7 @@ func CreateUser(ctx *gin.Context) {
 	 */
 
 	var dto CreateUserDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -58,7 +58,7 @@ func LoginUser(ctx *gin.Context) {
 	 */
 
 	var dto LoginUserDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -143,7 +143,7 @@ func VerifyToken(ctx *gin.Context) {
 	 */
 
 	var dto JoinTokenMatchDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -202,7 +202,7 @@ func GetCurrentUser(ctx *gin.Context) {
  */
 func BindAdminToCongregation(ctx *gin.Context) {
 	var dto BindAdminToCongregationDTO
-	err := common.BindAndValidate(ctx, dto)
+	err := common.BindAndValidate(ctx, &dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,

--- a/backend/core/api/user/views.go
+++ b/backend/core/api/user/views.go
@@ -21,7 +21,7 @@ func CreateUser(ctx *gin.Context) {
 	 */
 
 	var dto CreateUserDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -58,7 +58,7 @@ func LoginUser(ctx *gin.Context) {
 	 */
 
 	var dto LoginUserDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -143,7 +143,7 @@ func VerifyToken(ctx *gin.Context) {
 	 */
 
 	var dto JoinTokenMatchDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,
@@ -202,7 +202,7 @@ func GetCurrentUser(ctx *gin.Context) {
  */
 func BindAdminToCongregation(ctx *gin.Context) {
 	var dto BindAdminToCongregationDTO
-	err := ctx.BindJSON(&dto)
+	err := common.BindAndValidate(ctx, dto)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			common.UserErrorInstance.UserErrKey: common.UserErrorInstance.BadRequestOrData,

--- a/backend/core/common/error_handlers.go
+++ b/backend/core/common/error_handlers.go
@@ -1,23 +1,20 @@
-/* TODO */
-
 package common
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 )
 
-type ContextErrorHandle struct {
-	Context *gin.Context
-	Tag     string
-}
-
-func (handle ContextErrorHandle) RequestValidation(err error) {
-	if err != nil {
-		handle.Context.JSON(http.StatusBadRequest, gin.H{
-			UserErrorInstance.UserErrKey: UserErrorInstance.BadRequestOrData,
-		})
-		return
+// Validate DTOs by Binding JSON body and validating with validator
+func BindAndValidate(ctx *gin.Context, dto interface{}) error {
+	if err := ctx.BindJSON(dto); err != nil {
+		return err
 	}
+
+	validate := validator.New()
+	if err := validate.Struct(dto); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/backend/core/common/error_handlers.go
+++ b/backend/core/common/error_handlers.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 )
@@ -8,11 +10,13 @@ import (
 // Validate DTOs by Binding JSON body and validating with validator
 func BindAndValidate(ctx *gin.Context, dto interface{}) error {
 	if err := ctx.BindJSON(dto); err != nil {
+		fmt.Println(err)
 		return err
 	}
 
 	validate := validator.New()
 	if err := validate.Struct(dto); err != nil {
+		fmt.Println(err)
 		return err
 	}
 

--- a/packages/integration-tests/auth.ts
+++ b/packages/integration-tests/auth.ts
@@ -3,10 +3,10 @@ import { backendRoutes } from "frontend/lib/config";
 import { Congregation } from "frontend/lib/types/models/congregation";
 import { User } from "frontend/lib/types/models/user";
 
-export async function loginUser(user: User): Promise<string> {
+export async function loginUser(user: User, password: string): Promise<string> {
   const res = await axios.post(
     backendRoutes.user.login,
-    { email: user.email },
+    { email: user.email, password },
     {
       withCredentials: true,
     },

--- a/packages/integration-tests/endpoints/user.test.ts
+++ b/packages/integration-tests/endpoints/user.test.ts
@@ -10,7 +10,10 @@ describe("User CRUD", () => {
   it("should correctly create a user", async () => {
     const client = await DBClient.shared.getClient();
     const user = ModelGenerator.instance.randomUser();
-    const response = await axios.post(backendRoutes.user.create, user);
+    const response = await axios.post(backendRoutes.user.create, {
+      ...user,
+      password: "hello world",
+    });
 
     expect(response.data.user).not.toBe(undefined);
 

--- a/packages/integration-tests/security/token.test.ts
+++ b/packages/integration-tests/security/token.test.ts
@@ -36,12 +36,16 @@ describe("Join Token Security", () => {
       .parse(congregationResponse.data).congregation;
 
     // Create the users
-    const adminResponse = await axios.post(
-      backendRoutes.user.create,
-      adminUser,
-    );
+    const adminPassword = "hello! worldQ!";
+    const adminResponse = await axios.post(backendRoutes.user.create, {
+      ...adminUser,
+      password: adminPassword,
+    });
 
-    const joinResponse = await axios.post(backendRoutes.user.create, joinUser);
+    const joinResponse = await axios.post(backendRoutes.user.create, {
+      ...joinUser,
+      password: "hello,. world/!",
+    });
     // Check the response
     const adminPayload = createUserSchema.parse(adminResponse.data);
     const joinPayload = createUserSchema.parse(joinResponse.data);
@@ -49,7 +53,7 @@ describe("Join Token Security", () => {
     expect(joinPayload.user.id).toBeNumber();
 
     // Login the admin
-    const sessionToken = await loginUser(adminPayload.user);
+    const sessionToken = await loginUser(adminPayload.user, adminPassword);
     await bindAdminToCongregation(congregation, sessionToken);
 
     // Make the admin create the session token


### PR DESCRIPTION
If you make an empty request to one of our endpoints, it will just run fine, even if a DTO is required. This is because the DTO struct will get filled with Go's zero values.

This PR:
- Introduces go-validate to make fields required.
- Wrote a wrapper to validate the DTO doing the unmarshalling and validating to return the error.