### PR TITLE
fix: random incorrect routing

### DIFF
--- a/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
+++ b/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
@@ -43,14 +43,9 @@ export function PhoneNumberCheck() {
     resolver: zodResolver(formSchema),
   });
   const router = useRouter();
-  const selectedCongregation = useSelector((state: RootState) => {
-    if (state.localMeetings.selectedCongregation === undefined) {
-      router.replace("/register/weekly-meetings");
-      return;
-    }
-
-    return state.localMeetings.selectedCongregation;
-  });
+  const selectedCongregation = useSelector(
+    (state: RootState) => state.localMeetings.selectedCongregation,
+  );
 
   const startCountdown = React.useCallback((duration: number) => {
     setCountdown(duration);

--- a/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
+++ b/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
@@ -43,9 +43,14 @@ export function PhoneNumberCheck() {
     resolver: zodResolver(formSchema),
   });
   const router = useRouter();
-  const selectedCongregation = useSelector(
-    (state: RootState) => state.localMeetings.selectedCongregation,
-  );
+  const selectedCongregation = useSelector((state: RootState) => {
+    if (state.localMeetings.selectedCongregation === undefined) {
+      router.replace("/register/weekly-meetings");
+      return;
+    }
+
+    return state.localMeetings.selectedCongregation;
+  });
 
   const startCountdown = React.useCallback((duration: number) => {
     setCountdown(duration);

--- a/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
+++ b/packages/frontend/app/register/phone-number/components/phone-number-check.tsx
@@ -76,12 +76,6 @@ export function PhoneNumberCheck() {
     startCountdown(30);
   }, [countdown, form, selectedCongregation, startCountdown]);
 
-  React.useEffect(() => {
-    if (selectedCongregation === undefined) {
-      router.replace("/register/weekly-meetings");
-    }
-  }, [router, selectedCongregation]);
-
   const onSubmit = async () => {
     if (!selectedCongregation) {
       return;


### PR DESCRIPTION
When you click `Create Congregation` in the weekly-meetings page, you route to /register/phone-number. If selectedCongregation doesn't exist, you will go back to weekly-meetings which is not what we want. Because selectedCongregation is not updated immediately by redux.

To fix, I just moved this functionality to where we would be guaranteed to have the latest state. in the useSelector.